### PR TITLE
Add PDF support

### DIFF
--- a/audiobook_generator/book_parsers/base_book_parser.py
+++ b/audiobook_generator/book_parsers/base_book_parser.py
@@ -3,6 +3,7 @@ from typing import List, Tuple
 from audiobook_generator.config.general_config import GeneralConfig
 
 EPUB = "epub"
+PDF = "pdf"
 
 
 class BaseBookParser:  # Base interface for books parsers
@@ -33,13 +34,16 @@ class BaseBookParser:  # Base interface for books parsers
 # Common support methods for all book parsers
 
 def get_supported_book_parsers() -> List[str]:
-    return [EPUB]
+    return [EPUB, PDF]
 
 
 def get_book_parser(config) -> BaseBookParser:
     if config.input_file.endswith(EPUB):
         from audiobook_generator.book_parsers.epub_book_parser import EpubBookParser
         return EpubBookParser(config)
+    elif config.input_file.endswith(PDF):
+        from audiobook_generator.book_parsers.pdf_book_parser import PdfBookParser
+        return PdfBookParser(config)
     # elif <- new book parser goes here
     else:
         raise NotImplementedError(f"Unsupported file format: {config.input_file}")

--- a/audiobook_generator/book_parsers/pdf_book_parser.py
+++ b/audiobook_generator/book_parsers/pdf_book_parser.py
@@ -1,0 +1,81 @@
+import logging
+import re
+from typing import List, Tuple
+
+import fitz  # PyMuPDF
+
+from audiobook_generator.book_parsers.base_book_parser import BaseBookParser
+from audiobook_generator.config.general_config import GeneralConfig
+
+logger = logging.getLogger(__name__)
+
+
+class PdfBookParser(BaseBookParser):
+    def __init__(self, config: GeneralConfig):
+        super().__init__(config)
+        self.doc = fitz.open(self.config.input_file)
+
+    def __str__(self) -> str:
+        return super().__str__()
+
+    def validate_config(self):
+        if self.config.input_file is None:
+            raise ValueError("PDF Parser: Input file cannot be empty")
+        if not self.config.input_file.endswith(".pdf"):
+            raise ValueError(f"PDF Parser: Unsupported file format: {self.config.input_file}")
+
+    def get_book(self):
+        return self.doc
+
+    def get_book_title(self) -> str:
+        title = self.doc.metadata.get("title")
+        if title:
+            return title
+        return "Untitled"
+
+    def get_book_author(self) -> str:
+        author = self.doc.metadata.get("author")
+        if author:
+            return author
+        return "Unknown"
+
+    def get_chapters(self, break_string) -> List[Tuple[str, str]]:
+        text = ""
+        for page in self.doc:
+            text += page.get_text()
+            text += "\n"
+
+        # Normalize whitespaces similar to EPUB parser
+        if self.config.newline_mode == "single":
+            cleaned_text = re.sub(r"[\n]+", break_string, text.strip())
+        elif self.config.newline_mode == "double":
+            cleaned_text = re.sub(r"[\n]{2,}", break_string, text.strip())
+        elif self.config.newline_mode == "none":
+            cleaned_text = re.sub(r"[\n]+", " ", text.strip())
+        else:
+            raise ValueError(f"Invalid newline mode: {self.config.newline_mode}")
+
+        cleaned_text = re.sub(r"\s+", " ", cleaned_text)
+
+        if self.config.remove_endnotes:
+            cleaned_text = re.sub(r'(?<=[a-zA-Z.,!?;”")])\d+', "", cleaned_text)
+
+        if self.config.remove_reference_numbers:
+            cleaned_text = re.sub(r'\[\d+(\.\d+)?\]', '', cleaned_text)
+
+        search_and_replaces = self.get_search_and_replaces()
+        for sr in search_and_replaces:
+            cleaned_text = re.sub(sr['search'], sr['replace'], cleaned_text)
+
+        # Single chapter titled "Document"
+        return [("Document", cleaned_text)]
+
+    def get_search_and_replaces(self):
+        search_and_replaces = []
+        if self.config.search_and_replace_file:
+            with open(self.config.search_and_replace_file) as fp:
+                for line in fp.readlines():
+                    if '==' in line and not line.startswith('==') and not line.endswith('==') and not line.startswith('#'):
+                        search_and_replaces.append({'search': r"{}".format(line.split('==')[0]),
+                                                   'replace': r"{}".format(line.split('==')[1][:-1])})
+        return search_and_replaces

--- a/audiobook_generator/ui/web_ui.py
+++ b/audiobook_generator/ui/web_ui.py
@@ -109,6 +109,12 @@ def process_ui_form(input_file, output_dir, worker_count, log_level, output_text
     else:
         raise ValueError("Unsupported TTS provider selected")
 
+    try:
+        if os.path.getsize(config.input_file) > 10 * 1024 * 1024:
+            print("Warning: large files may lead to slow TTS generation.")
+    except Exception:
+        pass
+
     launch_audiobook_generator(config)
 
 
@@ -135,7 +141,8 @@ def host_ui(config):
     with gr.Blocks(analytics_enabled=False, title="Epub to Audiobook Converter") as ui:
         with gr.Row(equal_height=True):
             with gr.Column():
-                input_file = gr.File(label="Select the book file to process", file_types=[".epub"], 
+                input_file = gr.File(label="Select an EPUB or PDF file to convert into a podcast-style audio.",
+                                    file_types=[".epub", ".pdf"],
                                     file_count="single", interactive=True)
 
             with gr.Column():

--- a/examples/sample.pdf
+++ b/examples/sample.pdf
@@ -1,0 +1,52 @@
+%PDF-1.1
+1 0 obj
+<< /Type /Catalog
+   /Pages 2 0 R
+>>
+endobj
+2 0 obj
+<< /Type /Pages
+   /Kids [3 0 R]
+   /Count 1
+>>
+endobj
+3 0 obj
+<< /Type /Page
+   /Parent 2 0 R
+   /MediaBox [0 0 612 792]
+   /Contents 4 0 R
+   /Resources << /Font << /F1 5 0 R >> >>
+>>
+endobj
+4 0 obj
+<< /Length 44 >>
+stream
+BT
+  /F1 24 Tf
+  100 700 Td
+  (Hello, PDF!) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font
+   /Subtype /Type1
+   /Name /F1
+   /BaseFont /Helvetica
+>>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000010 00000 n 
+0000000061 00000 n 
+0000000118 00000 n 
+0000000213 00000 n 
+0000000341 00000 n 
+trailer
+<< /Root 1 0 R
+   /Size 6
+>>
+startxref
+444
+%%EOF

--- a/main.py
+++ b/main.py
@@ -11,7 +11,7 @@ from audiobook_generator.utils.log_handler import setup_logging, generate_unique
 
 def handle_args():
     parser = argparse.ArgumentParser(description="Convert text book to audiobook")
-    parser.add_argument("input_file", help="Path to the EPUB file")
+    parser.add_argument("input_file", help="Path to the EPUB or PDF file")
     parser.add_argument("output_folder", help="Path to the output folder")
     parser.add_argument(
         "--tts",

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ gradio==5.33.1
 docker==7.1.0
 sentencex==0.6.1
 gradio_log==0.0.8
+PyMuPDF==1.24.4

--- a/tests/audiobook_generator/book_parsers/pdf_book_parser_test.py
+++ b/tests/audiobook_generator/book_parsers/pdf_book_parser_test.py
@@ -1,0 +1,17 @@
+import unittest
+
+from audiobook_generator.book_parsers.base_book_parser import get_book_parser
+from audiobook_generator.book_parsers.pdf_book_parser import PdfBookParser
+from tests.test_utils import get_pdf_config
+
+
+class TestPdfBookParser(unittest.TestCase):
+    def test_get_pdf_book_parser(self):
+        config = get_pdf_config()
+        parser = get_book_parser(config)
+        self.assertIsInstance(parser, PdfBookParser)
+        self.assertEqual(len(parser.get_chapters("   ")), 1)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -42,3 +42,24 @@ def get_openai_config():
         speed=1.0
     )
     return GeneralConfig(args)
+
+
+def get_pdf_config():
+    args = MagicMock(
+        input_file='../../../examples/sample.pdf',
+        output_folder='output',
+        preview=False,
+        output_text=False,
+        log='INFO',
+        newline_mode='double',
+        chapter_start=1,
+        chapter_end=-1,
+        remove_endnotes=False,
+        tts='openai',
+        language='en-US',
+        voice_name='echo',
+        output_format='mp3',
+        model_name='tts-1',
+        speed=1.0
+    )
+    return GeneralConfig(args)


### PR DESCRIPTION
## Summary
- implement `PdfBookParser` using PyMuPDF
- detect PDF files in book parser factory
- allow uploading EPUB or PDF in the web UI and warn for large files
- document PDF support in CLI help
- add PyMuPDF to requirements
- add tests and example PDF file

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'ebooklib', 'fitz', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_685afe0e67708323bd406508d5df2bb0